### PR TITLE
Style: 모달창 화면 가운데로 고정하도록 수정

### DIFF
--- a/src/components/CouponCard.jsx
+++ b/src/components/CouponCard.jsx
@@ -65,7 +65,7 @@ const CouponCard = ({
         {/* 쿠폰 왼쪽 다운로드 영역*/}
         <div className="relative z-0">
           <div
-            className={`rounded-l-lg h-full w-16 flex flex-col items-center justify-center pl-4 pr-[18px] basis-1/4 overflow-hidden ${
+            className={`rounded-l-lg h-full w-16 flex flex-col items-center justify-center pl-4 pr-[18px] basis-1/4 ${
               couponData.useYn === "Y" ? "bg-custom-gray-300" : "bg-custom-pink"
             }`}
           >
@@ -391,7 +391,7 @@ const CouponCard = ({
             {/* 쿠폰 디자인 양쪽 원으로 파인 부분  */}
             {/* 흰색 아래 흰색을 덮어서 그위에 블러처리하면 안될려나? */}
 
-            <CouponSemicircleUI_Desktop borderColor={`custom-pink`} />
+            <CouponSemicircleUI_Desktop borderColor={`custom-pink`}/>
 
             <section className="flex flex-col items-center">
               <div className="w-11/12 border-dashed border-t-2 border-custom-pink text-center">
@@ -536,10 +536,10 @@ const CouponSemicircleUI_Desktop = ({ borderColor }) => {
   return (
     <>
       <div
-        className={`absolute w-14 h-14 bg-white rounded-full top-[306px] left-[-28px] border-4 border-${borderColor}`}
+        className={`absolute w-14 h-14 bg-white rounded-full top-[308px] left-[-20px] border-4 border-${borderColor}`}
       ></div>
       <div
-        className={`absolute w-14 h-14 bg-white rounded-full top-[306px] right-[-28px] border-4 border-${borderColor}`}
+        className={`absolute w-14 h-14 bg-white rounded-full top-[308px] right-[-20px] border-4 border-${borderColor}`}
       ></div>
     </>
   );
@@ -548,10 +548,10 @@ const CouponSemicircleUI_Mobile = ({ borderColor }) => {
   return (
     <>
       <div
-        className={`absolute w-10 h-10 bg-white rounded-full top-[200px] left-[-20px] border-4 border-${borderColor}`}
+        className={`absolute w-10 h-10 bg-white rounded-full top-[204px] left-[-15px] border-4 border-${borderColor}`}
       ></div>
       <div
-        className={`absolute w-10 h-10 bg-white rounded-full top-[200px] right-[-20px] border-4 border-${borderColor}`}
+        className={`absolute w-10 h-10 bg-white rounded-full top-[204px] right-[-15px] border-4 border-${borderColor}`}
       ></div>
     </>
   );

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -1,51 +1,36 @@
 import React from "react";
 import closeIcon from "../assets/modalCloseIcon.svg";
 
-const Modal = ({ isOpen, onClose, isCoupon,isLast, children }) => {
+const Modal = ({ isOpen, onClose, isCoupon, isLast, children }) => {
   if (!isOpen) return null;
 
   const handleClose = (e) => {
     if (e.target.id === "wrapper") onClose();
   };
 
-  // sticky로 어떻게 할수는 없을까?
   return (
     <div
-      className={`absolute inset-0 bg-opacity-25 backdrop-blur-xl flex justify-center z-10 ${
-        isCoupon ? null : "bg-black"
-      }`}
+      className="fixed inset-0 bg-opacity-25 backdrop-blur-xl flex justify-center items-center z-10"
       id="wrapper"
       onClick={handleClose}
     >
-      <div className="absolute top-24 md:top-10">
-        {/* 모달 내용 */}
-        <div className="w-fit truncate sticky">
-          {/* 모달 바디 */}
-          <div
-            className={`relative bg-white rounded-md ${
-              isCoupon ? `border-solid border-4 ${isLast ? "#B2B2B2":"border-custom-pink"}` : ""
-              }`
-            }
+      <div className="absolute w-auto overflow-hidden">
+        <div
+          className={` bg-white rounded-md border-solid border-4
+         ${isLast ? "border-gray-300" : "border-custom-pink"}`}
+        >
+          <button
+            className="absolute top-5 right-3 md:top-9 md:right-4 text-gray-500 cursor-pointer"
+            onClick={onClose}
           >
-            {/* 모달 닫기 버튼 */}
-            <button
-              className="absolute top-5 right-3 md:top-9 md:right-4 text-gray-500 cursor-pointer"
-              onClick={onClose}
-            >
-              <img src={closeIcon} alt="" />
-            </button>
+            <img src={closeIcon} alt="Close" />
+          </button>
 
-            {/* 모달 내용 */}
-            {/* <div className="p-4"> */}
-            <div className="">
-              {/* 모달 내용을 여기에 추가 */}
-              {children}
-            </div>
-          </div>
+          <div className="">{children}</div>
         </div>
       </div>
     </div>
   );
-}
+};
 
 export default Modal;

--- a/src/pages/Coupon.jsx
+++ b/src/pages/Coupon.jsx
@@ -85,12 +85,10 @@ const Coupon = () => {
     coupon.name.toLowerCase().includes(searchTerm.toLowerCase())
   );
 
-
-
   useEffect(() => {
     const fetchData = async () => {
       const token =
-        "naver_AAAAOIOXjfzp-hTjCVP9ZkoxUnkLy7wvJQVQoa0Vt8DHhMpRpyGyUsdxX4nyzOcz90mP8JOTy9IZvNVSwFj5uFozrU0";
+        "naver_AAAAOJJBFFgk1BwHCxhj3pZbwGSHmqQ4cvc_PVbBpTGxJUDsU2TKWZzdKOs4O3lx7m-yJC70jKgZ_kNVne-Xg4LDyAY";
       try {
         const response = await axios.get(`coupons`, {
           headers: {

--- a/src/pages/Header.jsx
+++ b/src/pages/Header.jsx
@@ -42,7 +42,7 @@ const DesktopHeader = () => {
   };
   return (
     //780px 이상일 때 보여지도록 설정
-    <div className="justify-between hidden h-40 md:px-6 lg:p-12 md:flex">
+    <div className="justify-between hidden h-40 md:px-6 lg:p-12 md:flex z-20">
       {/* 좌측영역: 로고, 검색창 */}
       <div className="flex items-center">
         {/* 로고 */}

--- a/src/pages/Navbar.jsx
+++ b/src/pages/Navbar.jsx
@@ -13,7 +13,7 @@ const Navbar = () => {
   };
   return (
     // 780px 부터 보이도록 설정
-    <div className="justify-between hidden w-full h-16 lg:px-16 md:px-6 md: md:flex shadow-custom-button-shadow">
+    <div className="justify-between hidden w-full h-16 lg:px-16 md:px-6 md: md:flex shadow-custom-button-shadow z-50">
       {/* 좌측영역: 이용가이드 및 상점, 메뉴 선택을 위한 네비게이션 */}
       <div className="flex items-center space-x-7">
         <CustomNavLink to="/user-guide">이용가이드</CustomNavLink>


### PR DESCRIPTION
# 🔥 Pull requests
### 🌴 작업한 브랜치
- #92 

### ✅ 작업한 내용
- 모달창을 고정 시켰더니, 쿠폰 페이지에서 맨 아래에 있는 쿠폰을 클릭했을때, 고정된 곳에 모달창이 띄워져 위로 스크롤을 해야하는 번거로움이 발생함
- 처음 작업을 했을때 fixed로 했지만 header와 nav가 가려지는 현상을 몰라 absolute로 변경했었음
- z-index를 각각에 부여하면 header, nav가 보이고 화면 가운데에 모달창이 보이도록 현재 수정함

### ❗️PR Point
- 데스크탑에서 띄운 쿠폰을 없앤 후, 모바일 뷰로 볼시, 모달창이 띄워지는 버그를 어떻게 해결해야할지 감이 안잡힘

### 📸 스크린샷

closed #92 
