### PR TITLE
Feat: 카카오는 6시간, 네이버는 1시간으로 토큰 만료시간 설정

### DIFF
--- a/src/contexts/LoginContextProvider.jsx
+++ b/src/contexts/LoginContextProvider.jsx
@@ -39,7 +39,13 @@ const LoginContextProvider = ({ children }) => {
   const loginSuccess = (token) => {
     localStorage.setItem("oauthToken", token); // 토큰을 로컬 스토리지에 저장
 
-    const expiresIn = 60 * 60;
+    let expiresIn; // 토큰 유효시간
+    if (token.startsWith("naver_")) {
+      expiresIn = 60 * 60; // 네이버는 1시간
+    } else {
+      expiresIn = 60 * 60 * 6; // 카카오는 6시간
+    }
+
     const expirationTime = new Date().getTime() + expiresIn * 1000; // 1000이 1초
     localStorage.setItem("tokenExpiration", expirationTime);
 


### PR DESCRIPTION
# 🔥 Pull requests
### 🌴 작업한 브랜치
- #128

### ✅ 작업한 내용
- 카카오는 6시간, 네이버는 1시간으로 토큰 만료시간 설정

closed #128 
